### PR TITLE
Add support for CocoaPods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ DerivedData
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
 #
 Pods/
+Rome/
 
 # Carthage
 #

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Apous is a simple tool that allows for easier authoring of Swift scripts.
 Primary features:
 
   1. Allow the breaking up of scripts into multiple files.
-  2. Dependency management through [Carthage](https://github.com/Carthage/Carthage).
+  2. Dependency management through [Carthage](https://github.com/Carthage/Carthage) or [CocoaPods](https://github.com/CocoaPods/CocoaPods/).
 
 # How it Works
 
-Apous works by first checking for a `Cartfile` in your script's directory. If one is
-present, then `carthage update` will be run. 
+Apous works by first checking for a `Cartfile` or `Podfile` in your script's directory. If one is
+present, then `carthage update` or `pod install --ono-integrate` will be run. 
 
 Next, all of your Swift files are combined into a single `.apous.swift` file that can
 then be run by the `swift` REPL.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Primary features:
 # How it Works
 
 Apous works by first checking for a `Cartfile` or `Podfile` in your script's directory. If one is
-present, then `carthage update` or `pod install --ono-integrate` will be run. 
+present, then `carthage update` or `pod install --no-integrate` will be run. 
 
 Next, all of your Swift files are combined into a single `.apous.swift` file that can
 then be run by the `swift` REPL.

--- a/samples/cocoapods/Podfile
+++ b/samples/cocoapods/Podfile
@@ -1,0 +1,6 @@
+platform :osx, '10.10'
+use_frameworks!
+
+plugin 'cocoapods-rome'
+
+pod "Argo", :git => "https://github.com/thoughtbot/Argo",  :branch => "td-swift-2"

--- a/samples/cocoapods/Podfile.lock
+++ b/samples/cocoapods/Podfile.lock
@@ -1,0 +1,23 @@
+PODS:
+  - Argo (1.0.3):
+    - Runes (>= 1.2.2)
+  - Runes (2.0.0)
+
+DEPENDENCIES:
+  - Argo (from `https://github.com/thoughtbot/Argo`, branch `td-swift-2`)
+
+EXTERNAL SOURCES:
+  Argo:
+    :branch: td-swift-2
+    :git: https://github.com/thoughtbot/Argo
+
+CHECKOUT OPTIONS:
+  Argo:
+    :commit: 5b18ce0da13e3e6d8a3a5188cbf00bd8d5c86a0c
+    :git: https://github.com/thoughtbot/Argo
+
+SPEC CHECKSUMS:
+  Argo: 541f7b9167f264ddf9c6c5d75a87e8c68e29929d
+  Runes: 4fe81355f4620b76b02176222d264b33e60dba51
+
+COCOAPODS: 0.38.0.beta.2

--- a/samples/cocoapods/main.swift
+++ b/samples/cocoapods/main.swift
@@ -1,0 +1,4 @@
+import Argo
+import Runes
+
+print("dependencies import properly")

--- a/src/ErrorCodes.swift
+++ b/src/ErrorCodes.swift
@@ -10,5 +10,6 @@ enum ErrorCode: Int, ErrorType {
     case InvalidUsage = 1
     case PathNotFound
     case CarthageNotInstalled
+    case CocoaPodsNotInstalled
     case SwiftNotInstalled
 }

--- a/src/main.swift
+++ b/src/main.swift
@@ -9,6 +9,8 @@
 import Foundation
 
 let CartfileConfig = "Cartfile"
+let PodfileConfig = "Podfile"
+
 let ApousScriptFile = ".apous.swift"
 
 // TODO(owensd): Pull this from a proper versioning tool.
@@ -46,17 +48,27 @@ func run() throws {
     }
 
     let path = try canonicalPath(scriptItem[0])
+    let fileManager = NSFileManager.defaultManager()
 
     // The tools need to be run under the context of the script directory.
-    NSFileManager.defaultManager().changeCurrentDirectoryPath(path)
+    fileManager.changeCurrentDirectoryPath(path)
 
-    if NSFileManager.defaultManager().fileExistsAtPath(path.stringByAppendingPathComponent(CartfileConfig)) {
+    if fileManager.fileExistsAtPath(path.stringByAppendingPathComponent(CartfileConfig)) {
         guard let carthage = CarthageTool() else {
             print("Carthage does not seem to be installed or in your path.")
             exit(.CarthageNotInstalled)
         }
         
         carthage.run("update")
+    }
+
+    if fileManager.fileExistsAtPath(path.stringByAppendingPathComponent(PodfileConfig)) {
+        guard let pods = CocoaPodsTool() else {
+            print("CocoaPods does not seem to be installed or in your path.")
+            exit(.CocoaPodsNotInstalled)
+        }
+
+        pods.run("install --no-integrate")
     }
 
     let files = filesAtPath(path)
@@ -74,7 +86,7 @@ func run() throws {
         exit(.SwiftNotInstalled)
     }
 
-    swift.run("-F", "Carthage/Build/Mac", scriptPath)
+    swift.run("-F", "Carthage/Build/Mac", "Rome", scriptPath)
 }
 
 try run()

--- a/src/main.swift
+++ b/src/main.swift
@@ -68,7 +68,7 @@ func run() throws {
             exit(.CocoaPodsNotInstalled)
         }
 
-        pods.run("install --no-integrate")
+        pods.run("install", "--no-integrate")
     }
 
     let files = filesAtPath(path)


### PR DESCRIPTION
By using a plugin CocoaPods can generate the frameworks for manual integration, so you can have a similar setup. I left the flushing out issue to you and just duped the code for the Tool, figure when you fix that once it'll fix for both Tools. 

Other than that, it should just hook up like with Carthage.

![screen shot 2015-07-06 at 09 43 24](https://cloud.githubusercontent.com/assets/49038/8518675/554a7d78-23c4-11e5-89a6-291b58f06bbd.png)